### PR TITLE
Use NethServer::SSSD library to chose ldap user and password.

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-webtop4-conf
+++ b/root/etc/e-smith/events/actions/nethserver-webtop4-conf
@@ -39,6 +39,3 @@ fi
 
 # Enable file upload/download
 setfacl -R -d -m postgres:rwx /var/lib/nethserver/webtop/tmp/
-
-perl -e "use NethServer::Directory qw(FIELDS_READ); my \$ldap = NethServer::Directory->new() || die('Could not connect LDAP server'); \$ldap->configServiceAccount('webtop', FIELDS_READ) || die('Error creating webtop LDAP service account');";
-

--- a/root/etc/e-smith/events/actions/nethserver-webtop4-domain
+++ b/root/etc/e-smith/events/actions/nethserver-webtop4-domain
@@ -3,6 +3,8 @@
 require File::Temp;
 use esmith::ConfigDB;
 use File::Temp();
+use NethServer::SSSD;
+my $sssd = new NethServer::SSSD();
 
 my $db = esmith::ConfigDB->open_ro() or die "Could not open config db";
 
@@ -12,13 +14,23 @@ chown $uid, $gid, $fh->filename;
 my $domain = $db->get('DomainName')->prop('type');
 print $fh "DELETE FROM domains;\n";
 
-my $secret=`cat /var/lib/nethserver/secrets/webtop`;
+my $secret=$sssd->bindPassword();
 chomp $secret;
 my $encoded=`cd /usr/share/webtop/;  CLASSPATH=\$CLASSPATH:. java WebtopPassEncode $secret`;
 chomp $encoded;
 
+my $user=$sssd->bindUser();
+
+my $uri = $sssd->ldapURI();
+if ($sssd->isLdap){
+    $uri =~ s/^ldap:\/\//ldapWebTop:\/\//;
+}
+elsif($sssd->isAD){
+    $uri =~ s/^ldap:\/\//ldapAD:\/\//;
+}
+
 my $order = 1;
-my $query="INSERT INTO domains (iddomain, description, domain, authuri, \"order\", enabled, adminldap, passwordldap, case_sensitive_auth, user_auto_creation, wt_adv_security) VALUES ('NethServer','$domain','$domain','ldapWebTop://localhost:389/','$order','T','webtop','$encoded','f','t','f');\n";
+my $query="INSERT INTO domains (iddomain, description, domain, authuri, \"order\", enabled, adminldap, passwordldap, case_sensitive_auth, user_auto_creation, wt_adv_security) VALUES ('NethServer','$domain','$domain','$uri','$order','T','$user','$encoded','f','t','f');\n";
 print $fh $query;
 
 my $public_url = $db->get_prop('webtop','PublicUrl') || 'http://'.$db->get('SystemName')->prop('type').'.'.$domain.'/webtop';


### PR DESCRIPTION
Also AD can now be a source of users. If local ldap auth is configured in sssd, libuser is used to query ldap instead of webtop user.
